### PR TITLE
Fix/msvc

### DIFF
--- a/chunk_view.hpp
+++ b/chunk_view.hpp
@@ -321,6 +321,9 @@ private:
     template <bool Const>
     using iterator = chunk_view_iterator<Const, V>;
 
+    friend iterator<false>;
+    friend iterator<true>;
+
 public:
     chunk_view()
         requires std::default_initializable<V>

--- a/chunk_view.hpp
+++ b/chunk_view.hpp
@@ -52,6 +52,21 @@ constexpr auto to_unsigned_like(T v) noexcept
     return static_cast<std::make_unsigned_t<T>>(v);
 }
 
+//!WORKAROUND MSVC
+// MSVC uses std::_Signed128 as range the type of std::ranges::range_difference_t<V>.
+// For this we require a conversion function.
+#if defined(_MSC_VER) && !defined(__clang__)
+constexpr auto to_unsigned_like(std::_Signed128 v) noexcept
+{
+    return static_cast<uint64_t>(v);
+}
+constexpr auto to_unsigned_like(std::_Unsigned128 v) noexcept
+{
+    return static_cast<uint64_t>(v);
+}
+#endif
+
+
 } // namespace seqan::stl::detail::chunk
 
 namespace seqan::stl::ranges

--- a/to.hpp
+++ b/to.hpp
@@ -144,7 +144,11 @@ constexpr C to(R && r, Args &&... args)
                              }),
                      std::forward<Args>(args)...);
     else
+    #if defined(_MSC_VER) && !defined(__clang__) // MSVC
+        __assume(false);
+    #else // GCC– Clang
         __builtin_unreachable();
+    #endif
 }
 
 template <template <class...> class C, std::ranges::input_range R, class... Args>
@@ -166,7 +170,11 @@ constexpr auto to(R && r, Args &&... args)
                              std::declval<seqan::stl::detail::to::input_iterator<R>>(),
                              std::declval<Args>()...))>(std::forward<R>(r), std::forward<Args>(args)...);
     else
+    #if defined(_MSC_VER) && !defined(__clang__) // MSVC
+        __assume(false);
+    #else // GCC– Clang
         __builtin_unreachable();
+    #endif
 }
 
 } // namespace seqan::stl::ranges


### PR DESCRIPTION
fixes a few things, such that it compiles with msvc c++20
- chunk_view.hpp: `to_unsigned_like()` for std::_Signed128
- chunk_view.hpp: de-nest iterator, because of compiler bug
- to.hpp: replace `__builtin_unerachable()` with `__assume(false)` for msvc