### PR TITLE
fix: add missing declaration for __int128 types

### DIFF
--- a/chunk_view.hpp
+++ b/chunk_view.hpp
@@ -53,38 +53,28 @@ constexpr auto to_unsigned_like(T v) noexcept
     return static_cast<std::make_unsigned_t<T>>(v);
 }
 
-//!WORKAROUND MSVC
-// MSVC uses std::_Signed128 as range the type of std::ranges::range_difference_t<V>.
-// For this we require a conversion function.
-#if defined(_MSC_VER) && !defined(__clang__)
-constexpr auto to_unsigned_like(std::_Signed128 v) noexcept
-{
-    return static_cast<uint64_t>(v);
-}
-constexpr auto to_unsigned_like(std::_Unsigned128 v) noexcept
-{
-    return static_cast<uint64_t>(v);
-}
+// !WORKAROUND: some STD libraries are using non standardized types
+// for return values in std::ranges::distance().
+// We call the to_unsigned_like() on these types and we must handle them
+// correctly.
+// MSVC: is using std::_Signed128
+// stdlibc++: is using __int128
+if defined(_MSC_VER) && !defined(__clang__)
+    using max_signed_t = std::_Signed128;
+    using max_unsigned_t = std::_Unsigned128;
+#else
+    __extension__ using max_signed_t = __int128;
+    __extension__ using max_unsigned_t = unsigned __int128;
 #endif
 
-//!WORKAROUND GCC/Clang and libstdc++
-// GCC uses __int128 as range type of example std::ranges::iota_view<size_t>
-// For this we require a conversion function, that
-// does not mention __int128, otherwise -pedantic will complain
-#if defined(__GNUC__) && !defined(_LIBCPP_VERSION)
-template <typename T>
-    requires (!std::integral<T> && requires(T v) { std::ranges::__detail::__to_unsigned_like(v); })
-constexpr auto to_unsigned_like(T v) noexcept
+constexpr auto to_unsigned_like(max_signed_t v) noexcept
 {
-    return std::ranges::__detail::__to_unsigned_like(v);
+    return static_cast<max_unsigned_t>(v);
 }
-template <typename T>
-    requires (!std::integral<T> && requires(T v) { std::ranges::__detail::__to_signed_like(v); })
-constexpr auto to_signed_like(T v) noexcept
+constexpr auto to_unsigned_like(max_unsigned_t v) noexcept
 {
-    return std::ranges::__detail::__to_signed_like(v);
+    return static_cast<max_unsigned_t>(v);
 }
-#endif
 
 } // namespace seqan::stl::detail::chunk
 


### PR DESCRIPTION
libstdc++ also uses a 128bit type `__int128` as a return value for some views.
This collides with the `to_unsigned_like` not having a `__int128` overload, which is not a `std::integral`.
Additionally, using `__int128`  will trigger a complaint from the compiler when using `-Wpedantic`, that `__int128` is non C++-ISO conform.

This PR implements a solution that allows any `non-integral` types, that know how to `static_cast` to an `uint64_t` to be used with `to_unsigned_like`.
(Sadly, this solution does not work for MSVC, because `std::convertible_to` is not true for `std::_Signed128` even though static_cast to `uint64_t` is possible)

Here is a playground with the fix included:
- [~~https://godbolt.org/z/5d3Pbf7WM~~](https://godbolt.org/z/5d3Pbf7WM)
- https://godbolt.org/z/1sPdWefs1