### PR TITLE
Fix/smaller stuff

### DIFF
--- a/chunk_view.hpp
+++ b/chunk_view.hpp
@@ -437,7 +437,7 @@ private:
         missing_{missing}
     {}
 
-    friend chunk_view;
+    friend chunk_view<V>;
 
 public:
     using iterator_category = std::input_iterator_tag;

--- a/chunk_view.hpp
+++ b/chunk_view.hpp
@@ -59,7 +59,7 @@ constexpr auto to_unsigned_like(T v) noexcept
 // correctly.
 // MSVC: is using std::_Signed128
 // stdlibc++: is using __int128
-if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_MSC_VER) && !defined(__clang__)
     using max_signed_t = std::_Signed128;
     using max_unsigned_t = std::_Unsigned128;
 #else


### PR DESCRIPTION
When running `g++ -x c++ -std=c++20 chunk_view.hpp` two errors appear.
- a missing `#` infront of an if-statement
- a missing template declaration

This PR adds these two things